### PR TITLE
[DO NOT MERGE] Validate save_cache --exclude on a real agent for #233

### DIFF
--- a/.buildkite/pipeline-bash-tests.yml
+++ b/.buildkite/pipeline-bash-tests.yml
@@ -8,6 +8,13 @@ env:
   IMAGE_ID: $IMAGE_ID
 
 steps:
+  # VALIDATION ONLY — not for merge. Runs first so it answers before the slow jobs.
+  - label: ":package: save_cache --exclude round trip"
+    command: tests/save_cache/test_exclude_round_trip.sh
+    notify:
+      - github_commit_status:
+          context: "save_cache: --exclude round trip"
+
   - group: ":c: get_libc_version Tests"
     steps:
       - label: ":c: Test get_libc_version on {{matrix}}"

--- a/tests/save_cache/test_exclude_round_trip.sh
+++ b/tests/save_cache/test_exclude_round_trip.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# VALIDATION ONLY — this file is not meant to be merged. See the PR description.
+#
+# The ordinary suite never runs `save_cache`'s tar-and-upload leg on an agent: the
+# `install_swiftpm_dependencies` fixtures always hit an existing cache entry and log
+# "This file is already cached – skipping upload". So `--exclude` has only ever been
+# exercised under GNU tar in the bats container. This runs the real round trip —
+# tar, upload, restore — on a macOS agent, with a unique key per build so it cannot hit.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PATH="$PATH:$REPO_ROOT/bin"
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+CASE_INDEX=0
+FIRST_KEY=
+
+echo "--- :mag: Environment"
+bash --version | head -1
+tar --version | head -1
+
+fail() {
+  echo "❌ $1"
+  exit 1
+}
+
+make_fixture() {
+  local dir=$1
+  # `repositories/artifacts` is a decoy: the same basename one level down. GNU tar and bsdtar
+  # disagree about whether `./artifacts` reaches it, so its fate is reported, never asserted.
+  mkdir -p "$dir/artifacts" "$dir/manifests" "$dir/repositories/artifacts"
+  echo excluded-payload > "$dir/artifacts/One.zip"
+  echo kept-payload > "$dir/manifests/manifest.json"
+  echo nested-payload > "$dir/repositories/artifacts/decoy"
+}
+
+# Saves a fresh fixture under a key that cannot already exist, restores it into an empty
+# directory, and asserts on what came back. $2 says whether `artifacts/` should have survived.
+round_trip() {
+  local label=$1 expect_artifacts=$2
+  shift 2
+
+  CASE_INDEX=$((CASE_INDEX + 1))
+  local key="save-cache-exclude-validation-${BUILDKITE_BUILD_ID:-local}-${CASE_INDEX}"
+  [[ -n "$FIRST_KEY" ]] || FIRST_KEY=$key
+
+  local case_dir="$SCRATCH/case-$CASE_INDEX"
+  local source_dir="$case_dir/source"
+  local restored_dir="$case_dir/restored"
+  mkdir -p "$source_dir" "$restored_dir"
+  make_fixture "$source_dir"
+
+  echo "--- :package: $label"
+  (cd "$case_dir" && save_cache "$source_dir" "$key" --use_relative_path_in_tar "$@")
+  (cd "$restored_dir" && restore_cache "$key")
+
+  # A cache miss on restore also exits 0, so prove the round trip happened at all.
+  [[ -f "$restored_dir/manifests/manifest.json" ]] ||
+    fail "Nothing was restored for '$key' — the archive never made it to the bucket."
+  [[ "$(cat "$restored_dir/manifests/manifest.json")" == 'kept-payload' ]] ||
+    fail "The restored sibling file does not hold what was saved."
+
+  if [[ "$expect_artifacts" == 'kept' ]]; then
+    [[ -f "$restored_dir/artifacts/One.zip" ]] ||
+      fail "Without --exclude, 'artifacts/' should be in the archive, and it is not."
+    echo "✅ Without --exclude the archive carries 'artifacts/', so the exclusion is what removes it."
+  else
+    [[ ! -e "$restored_dir/artifacts" ]] ||
+      fail "--exclude did not keep 'artifacts/' out of the uploaded archive."
+    echo "✅ '--exclude ./artifacts' kept 'artifacts/' out of the archive; 'manifests/' survived."
+
+    if [[ -e "$restored_dir/repositories/artifacts/decoy" ]]; then
+      echo "ℹ️  Observed: the nested 'repositories/artifacts' survived — this tar anchors './artifacts'."
+    else
+      echo "ℹ️  Observed: the nested 'repositories/artifacts' was excluded too — this tar does not anchor './artifacts'."
+    fi
+  fi
+}
+
+round_trip "Round trip with --exclude" excluded --exclude ./artifacts
+round_trip "Round trip without --exclude (negative control)" kept
+
+# These only need the parser to accept them, so they reuse a key already uploaded above:
+# `save_cache` parses its arguments before it ever asks S3 whether the key exists.
+echo "--- :older_man: Pre-flag calling conventions, on this agent's bash"
+PARSE_DIR="$SCRATCH/parse"
+mkdir -p "$PARSE_DIR"
+make_fixture "$PARSE_DIR"
+
+(cd "$PARSE_DIR" && save_cache "$PARSE_DIR" "$FIRST_KEY" false --use_relative_path_in_tar) ||
+  fail "A bare 'false' where --force goes is no longer accepted."
+echo "✅ 'PATH KEY false --use_relative_path_in_tar' still parses."
+
+(cd "$PARSE_DIR" && save_cache "$PARSE_DIR" "$FIRST_KEY" "") ||
+  fail "An empty string where --force goes is no longer accepted — this would break beeper."
+echo "✅ 'PATH KEY \"\"' still parses."
+
+echo "--- :no_entry: A genuinely unexpected argument is still rejected"
+if UNEXPECTED_OUTPUT=$(cd "$PARSE_DIR" && save_cache "$PARSE_DIR" "$FIRST_KEY" surprise 2>&1); then
+  fail "An unrecognised argument was accepted instead of rejected."
+fi
+grep -q 'Unexpected argument: surprise' <<< "$UNEXPECTED_OUTPUT" ||
+  fail "The command failed, but not through its own guard. It said: $UNEXPECTED_OUTPUT"
+echo "✅ Rejected through the guard, not by accident."
+
+echo "--- :white_check_mark: Every assertion passed"


### PR DESCRIPTION
**Validation only — do not merge.** Stacked on `ainfra-2909-investigate-swiftpm-binary-target-caching`, the head of #233, so the step runs against exactly the code under review. It will be closed as soon as it has answered.

## Why the ordinary pipeline misses this

#233 moves the artifact exclusion into `save_cache`'s `tar` invocation. Nothing in CI runs that invocation on an agent: every `install_swiftpm_dependencies` fixture job restores an existing cache entry and stops at

```
~~~ Saving SPM Cache
This file is already cached – skipping upload
```

(build [1461](https://buildkite.com/automattic/ci-toolkit-buildkite-plugin/builds/1461#01a055bb-26ee-4d68-a7e9-bdc34a8e04b9), and every green build before it). The key never moves, because a `binaryTarget` is pinned by checksum in `Package.swift` and never reaches `Package.resolved` — so even adding one to the fixture left the entry in place.

That leaves `--exclude` covered only by `tests/test_save_cache.bats`, which runs in the `buildkite/plugin-tester` container: **GNU tar on Linux**. The agents are **bsdtar on macOS, under bash 3.2**, and the two tars do not agree about exclusion patterns.

## What to read, and what to expect

One job: **`:package: save_cache --exclude round trip`**, first in the bash-tests pipeline. **Every step in it is expected to pass.** There is no intentional failure here — a red job means a real finding.

It saves a fixture under a key containing `$BUILDKITE_BUILD_ID`, so the upload leg cannot be skipped, then restores it into an empty directory and asserts on what came back.

- **`--exclude ./artifacts` keeps `artifacts/` out of the uploaded archive, and `manifests/` in it.** The claim #233 rests on, end to end: tar, upload, restore.
- **The same round trip without `--exclude` brings `artifacts/` back.** The negative control — without it, a restore that silently produced nothing would read as a pass.
- **A restored sibling file still holds what was saved.** `restore_cache` exits 0 on a miss, so this is what proves the round trip happened at all.
- **`PATH KEY false --use_relative_path_in_tar` and `PATH KEY ""` still parse**, on the agent's own bash. #233's backwards-compatibility claim; the empty string is what beeper's `cache-bundle.sh` passes.
- **`PATH KEY surprise` fails through the guard**, matched on its message rather than its exit code, so an unrelated failure cannot pass for a rejection.

The job also logs, without asserting, whether this tar anchors `./artifacts` or also matches a nested `repositories/artifacts`. The two implementations differ and #233 only promises top-level exclusion; this records which side the agents are on.

## What this still cannot answer

Nothing about **Stage B**. Artifacts remain out of the tarball, so this proves the exclusion works, not that a cache carrying ~1 GB of XCFrameworks would restore safely. That needs the atomic-restore work first.

It also says nothing about the **Day One** end of it: [AINFRA-2990](https://linear.app/a8c/issue/AINFRA-2990) is blocked on `doapple` bumping `CI_TOOLKIT_PLUGIN_VERSION` from 6.2.0, and the measured win in #233 comes from build [9305](https://buildkite.com/automattic/day-one-apple/builds/9305) over there.

Pre-flighted locally on macOS 26.6 (bash 3.2.57, bsdtar 3.5.3) with S3 stubbed: all assertions passed, real `tar` throughout. The agent image and real S3 are what remain.

---

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*
