### PR TITLE
Release 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- Remove `git-conceal-unlock` helper, given the tool was never used and is now superseded by `a8c-secrets`. [#235]
-- Remove all CocoaPods-related commands, and stop auto-installing CocoaPods dependencies in `lint_localized_strings_format`. [#236]
+_None._
 
 ### New Features
 
@@ -44,6 +43,17 @@ _None._
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## 7.0.0
+
+### Breaking Changes
+
+- Remove `git-conceal-unlock` helper, given the tool was never used and is now superseded by `a8c-secrets`. [#235]
+- Remove all CocoaPods-related commands, and stop auto-installing CocoaPods dependencies in `lint_localized_strings_format`. [#236]
 
 ### Internal Changes
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#6.3.0:
+      - automattic/a8c-ci-toolkit#7.0.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.3.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `7.0.0`.
 
 ## Configuration
 
@@ -51,7 +51,7 @@ steps:
 
       checkout_release_branch "$RELEASE_VERSION"
     plugins:
-      - automattic/a8c-ci-toolkit#6.3.0
+      - automattic/a8c-ci-toolkit#7.0.0
       - docker#v5.13.0:
           image: node:22-bookworm
           expand-volume-vars: true


### PR DESCRIPTION
Prepares the `7.0.0` release: moves the `Unreleased` changelog section under a `7.0.0` heading and points the `README.md` plugin references at the new version.

Major bump because the two entries under Breaking Changes remove commands consumers may still call — `git-conceal-unlock` and the CocoaPods family, including the implicit `pod install` inside `lint_localized_strings_format`.

## 7.0.0

### Breaking Changes

- Remove `git-conceal-unlock` helper, given the tool was never used and is now superseded by `a8c-secrets`. [#235]
- Remove all CocoaPods-related commands, and stop auto-installing CocoaPods dependencies in `lint_localized_strings_format`. [#236]

### Internal Changes

- `setup_azure_trusted_signing` documents why `AZURE_TIMESTAMP_SERVER` needs the `http://` scheme. [#232]

## How to test

`make` (lint + test).